### PR TITLE
Fix creation of empty GtkTreeModel

### DIFF
--- a/pyqso/logbook.py
+++ b/pyqso/logbook.py
@@ -182,7 +182,7 @@ class Logbook(Gtk.Notebook):
 
    def _create_dummy_page(self):
       """ Create a blank page in the Gtk.Notebook for the "+" (New Log) tab. """
-      blank_treeview = Gtk.TreeView([])
+      blank_treeview = Gtk.TreeView()
       # Allow the Log to be scrolled up/down
       sw = Gtk.ScrolledWindow()
       sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)


### PR DESCRIPTION
Fixes this error that I get since I upgraded my system:

Traceback (most recent call last):
  File "/home/pl/pyqso-master/bin/../pyqso/logbook.py", line 81, in open
    self._create_dummy_page()
  File "/home/pl/pyqso-master/bin/../pyqso/logbook.py", line 185, in _create_dummy_page
    blank_treeview = Gtk.TreeView([])
  File "/usr/lib/python2.7/dist-packages/gi/overrides/__init__.py", line 175, in new_init
    return super_init_func(self, **new_kwargs)
TypeError: could not convert value for property `model' from list to GtkTreeModel

73 de Paride IA/IZ3SUS
