### PR TITLE
DX cluster bookmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added a table of keyboard shortcuts to the documentation.
 - More helpful messages regarding missing dependencies.
 - Added the option of merging the COMMENT field with the NOTES field when importing records from an ADIF file.
+- Bookmarking of Telnet-based DX cluster servers.
 
 ### Changed
 - Ported the codebase over to Python 3 using 2to3 (thanks to Neil Johnson).

--- a/pyqso/dx_cluster.py
+++ b/pyqso/dx_cluster.py
@@ -51,13 +51,27 @@ class DXCluster(Gtk.VBox):
       mitem_connection.set_submenu(subm_connection)
 
       # Connect
-      mitem_connect = Gtk.ImageMenuItem("Connect to Telnet Server...")
+      mitem_connect = Gtk.ImageMenuItem("Connect to Telnet Server")
       icon = Gtk.Image()
       icon.set_from_stock(Gtk.STOCK_CONNECT, Gtk.IconSize.MENU)
       mitem_connect.set_image(icon)
-      mitem_connect.connect("activate", self.telnet_connect)
       subm_connection.append(mitem_connect)
       self.items["CONNECT"] = mitem_connect
+
+      subm_connect = Gtk.Menu()
+      
+      ## New
+      mitem_new = Gtk.MenuItem("New...")
+      mitem_new.connect("activate", self.telnet_connect)
+      subm_connect.append(mitem_new)
+
+      ## From Bookmark
+      mitem_bookmark = Gtk.MenuItem("From Bookmark")
+      subm_bookmarks = Gtk.Menu()
+      mitem_bookmark.set_submenu(subm_bookmarks)
+      subm_connect.append(mitem_bookmark)
+      
+      mitem_connect.set_submenu(subm_connect)
 
       # Disconnect
       mitem_disconnect = Gtk.ImageMenuItem("Disconnect from Telnet Server")
@@ -67,6 +81,8 @@ class DXCluster(Gtk.VBox):
       mitem_disconnect.connect("activate", self.telnet_disconnect)
       subm_connection.append(mitem_disconnect)
       self.items["DISCONNECT"] = mitem_disconnect
+
+
       
       self.pack_start(self.menubar, False, False, 0)
 

--- a/pyqso/dx_cluster.py
+++ b/pyqso/dx_cluster.py
@@ -47,13 +47,13 @@ class DXCluster(Gtk.VBox):
       self.items = {}
       
       ###### CONNECTION ######
-      mitem_connection = Gtk.MenuItem("Connection")
+      mitem_connection = Gtk.MenuItem(label="Connection")
       self.menubar.append(mitem_connection)  
       subm_connection = Gtk.Menu()
       mitem_connection.set_submenu(subm_connection)
 
       # Connect
-      mitem_connect = Gtk.ImageMenuItem("Connect to Telnet Server")
+      mitem_connect = Gtk.ImageMenuItem(label="Connect to Telnet Server")
       icon = Gtk.Image()
       icon.set_from_stock(Gtk.STOCK_CONNECT, Gtk.IconSize.MENU)
       mitem_connect.set_image(icon)
@@ -63,12 +63,12 @@ class DXCluster(Gtk.VBox):
       subm_connect = Gtk.Menu()
       
       ## New
-      mitem_new = Gtk.MenuItem("New...")
+      mitem_new = Gtk.MenuItem(label="New...")
       mitem_new.connect("activate", self.new_server)
       subm_connect.append(mitem_new)
 
       ## From Bookmark
-      mitem_bookmark = Gtk.MenuItem("From Bookmark")
+      mitem_bookmark = Gtk.MenuItem(label="From Bookmark")
       self.subm_bookmarks = Gtk.Menu()
       mitem_bookmark.set_submenu(self.subm_bookmarks)
       self._populate_bookmarks()
@@ -77,7 +77,7 @@ class DXCluster(Gtk.VBox):
       mitem_connect.set_submenu(subm_connect)
 
       # Disconnect
-      mitem_disconnect = Gtk.ImageMenuItem("Disconnect from Telnet Server")
+      mitem_disconnect = Gtk.ImageMenuItem(label="Disconnect from Telnet Server")
       icon = Gtk.Image()
       icon.set_from_stock(Gtk.STOCK_DISCONNECT, Gtk.IconSize.MENU)
       mitem_disconnect.set_image(icon)
@@ -181,7 +181,7 @@ class DXCluster(Gtk.VBox):
 
             # Add all bookmarks in the config file.
             for bookmark in config.sections():
-               mitem = Gtk.MenuItem(bookmark)
+               mitem = Gtk.MenuItem(label=bookmark)
                mitem.connect("activate", self.bookmarked_server, bookmark)
                self.subm_bookmarks.append(mitem)
 

--- a/pyqso/dx_cluster.py
+++ b/pyqso/dx_cluster.py
@@ -81,16 +81,14 @@ class DXCluster(Gtk.VBox):
       self.buffer = self.renderer.get_buffer()
       self.pack_start(sw, True, True, 0)
 
-      # Set up the toolbar
-      self.toolbar = Gtk.HBox(spacing=2)
-      
+      # Set up the command box.
+      self.commandbox = Gtk.HBox(spacing=2)
       self.command = Gtk.Entry()
-      self.toolbar.pack_start(self.command, True, True, 0)
+      self.commandbox.pack_start(self.command, True, True, 0)
       self.send = Gtk.Button(label="Send Command")
       self.send.connect("clicked", self.telnet_send_command)
-      self.toolbar.pack_start(self.send, False, False, 0)
-
-      self.pack_start(self.toolbar, False, False, 0)
+      self.commandbox.pack_start(self.send, False, False, 0)
+      self.pack_start(self.commandbox, False, False, 0)
       
       self.set_items_sensitive(True)
             

--- a/pyqso/dx_cluster.py
+++ b/pyqso/dx_cluster.py
@@ -27,6 +27,8 @@ import os.path
 
 from pyqso.telnet_connection_dialog import *
 
+BOOKMARKS_FILE = os.path.expanduser('~/.pyqso_bookmarks.ini')
+
 class DXCluster(Gtk.VBox):
    """ A tool for connecting to a DX cluster (specifically Telnet-based DX clusters). """
    
@@ -131,7 +133,7 @@ class DXCluster(Gtk.VBox):
          if(connection_info["BOOKMARK"].get_active()):
             try:
                config = configparser.ConfigParser()
-               config.read(os.path.expanduser('~/.pyqso_bookmarks.ini'))
+               config.read(BOOKMARKS_FILE)
                
                # Use the host name as the bookmark's identifier.
                try:
@@ -144,7 +146,7 @@ class DXCluster(Gtk.VBox):
                config.set(host, "username", username)
                config.set(host, "password", password)
 
-               with open(os.path.expanduser('~/.pyqso_bookmarks.ini'), 'w') as f:
+               with open(BOOKMARKS_FILE, 'w') as f:
                   config.write(f)
                   
                self._populate_bookmarks()
@@ -171,7 +173,7 @@ class DXCluster(Gtk.VBox):
    def _populate_bookmarks(self):
       """ Populate the list of bookmarked Telnet servers in the menu. """
       config = configparser.ConfigParser()
-      have_config = (config.read(os.path.expanduser('~/.pyqso_bookmarks.ini')) != [])
+      have_config = (config.read(BOOKMARKS_FILE) != [])
 
       if(have_config):
          try:
@@ -200,7 +202,7 @@ class DXCluster(Gtk.VBox):
       """
       
       config = configparser.ConfigParser()
-      have_config = (config.read(os.path.expanduser('~/.pyqso_bookmarks.ini')) != [])
+      have_config = (config.read(BOOKMARKS_FILE) != [])
       try:
          if(not have_config):
             raise IOError("The bookmark's details could not be loaded.")

--- a/pyqso/telnet_connection_dialog.py
+++ b/pyqso/telnet_connection_dialog.py
@@ -72,6 +72,9 @@ class TelnetConnectionDialog(Gtk.Dialog):
       self.sources["PASSWORD"].set_visibility(False) # Mask the password with the "*" character.
       hbox_temp.pack_start(self.sources["PASSWORD"], True, True, 6)
       self.vbox.pack_start(hbox_temp, False, False, 6)
+      
+      self.sources["BOOKMARK"] = Gtk.CheckButton("Bookmark server details for next time")
+      self.vbox.pack_start(self.sources["BOOKMARK"], False, False, 6)
 
       logging.debug("Telnet connection dialog ready!") 
 


### PR DESCRIPTION
Introduces functionality to bookmark Telnet-based DX cluster servers. Addresses issue #22.

This also removes the existing toolbar in the DX cluster tool, and replaces it with a menu instead. The "Send Command" button is placed under the server output box.