### PR TITLE
Corrected log deletion bug.

### DIFF
--- a/pyqso/logbook.py
+++ b/pyqso/logbook.py
@@ -345,6 +345,7 @@ class Logbook:
             self.sorter.pop(log_index)
             self.filter.pop(log_index)
             # And finally remove the tab in the Logbook.
+            self.notebook.set_current_page(page_index - 1)
             self.notebook.remove_page(page_index)
 
         self.summary.update()


### PR DESCRIPTION
This one line addition to logbook.py corrects a bug which occurs when you delete the last log in the logbook (the log on the tab furthest to the right).  The original code without the addition causes the notebook widget to disappear from the window necessitating the user to close the logbook and re-open it.  By making the previous page the currently selected page before the remove_page() call, this bug does not occur.  Another option might to be to automatically select page 0 (the summary page) instead of the what will become the new last page in the notebook.