### PR TITLE
Remove unneeded print with Python 2 syntax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,6 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-print os.path.abspath(".")
 sys.path.insert(0, os.path.abspath('../../'))
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Fixes error with Python 3.

Found by Daniele Forsi while working on the Debian pyqso package.

https://salsa.debian.org/debian-hamradio-team/pyqso/-/merge_requests/4